### PR TITLE
[BUG]Fix bug of `haproxy_stats_socket_path` on defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,4 +30,4 @@ haproxy_global_logging:
 haproxy_group: haproxy
 haproxy_listens: []
 haproxy_user: haproxy
-haproxy_stats_socket_path: /run/haproxy/admin.sock
+haproxy_stats_socket_path: /run/haproxy/


### PR DESCRIPTION
Hi

I found the bug during re-running playbook against already configured hosts.

This PR fix the bug of `haproxy_stats_socket_path` which caused by this PR: https://github.com/wtanaka/ansible-role-haproxy/pull/14

https://github.com/wtanaka/ansible-role-haproxy/pull/14/commits/787fb28279c67661bc7ec1776bd8725cc9d11ae4

Due to this bug, task `Ensure {{ haproxy_stats_socket_path ]}` will fails because socket file itself(not  its parent directory) must have `600` permission.

JFYI: correct permission of directory
 /run/haproxy/ => 2775
/run/haproxy/admin.sock> 600

 `/run/haproxy/admin.sock` is existing some cases if haproxy is already started once, this task will fail.

and this bug also causes misconfiguration on haproxy.cfg(https://github.com/wtanaka/ansible-role-haproxy/blob/master/templates/haproxy.cfg.j2#L6)